### PR TITLE
Don't auto-merge Fyne dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,45 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      go-dependencies:
+      # fsnotify, gopsutil, and yaml.v3 are the only non-Fyne dependencies,
+      # and the code that wraps each of them is heavily unit-tested (config
+      # load/save for yaml.v3, process detection for gopsutil) — patch/minor
+      # bumps here auto-merge on green CI (see ci.yml's
+      # dependabot-auto-merge job). gopsutil's own per-OS backends are
+      # included too, since they move in lockstep with it and are exercised
+      # by the same tests.
+      go-dependencies-safe:
+        patterns:
+          - "github.com/fsnotify/fsnotify"
+          - "github.com/shirou/gopsutil/v4"
+          - "gopkg.in/yaml.v3"
+          - "github.com/go-ole/go-ole"
+          - "github.com/lufia/plan9stats"
+          - "github.com/power-devops/perfstat"
+          - "github.com/tklauser/go-sysconf"
+          - "github.com/tklauser/numcpus"
+          - "github.com/yusufpapurcu/wmi"
+          - "golang.org/x/sys"
+      # Everything else — in practice, the fyne.io/fyne/v2 tree (rendering,
+      # windowing, systray, text/image handling). This app is deeply
+      # integrated with Fyne (custom widgets, a custom fyne.Layout, a custom
+      # theme) and none of that live-wiring has the kind of test coverage
+      # the safe group's code does, so this group never auto-merges
+      # regardless of update-type — see ci.yml.
+      fyne:
         patterns:
           - "*"
+        exclude-patterns:
+          - "github.com/fsnotify/fsnotify"
+          - "github.com/shirou/gopsutil/v4"
+          - "gopkg.in/yaml.v3"
+          - "github.com/go-ole/go-ole"
+          - "github.com/lufia/plan9stats"
+          - "github.com/power-devops/perfstat"
+          - "github.com/tklauser/go-sysconf"
+          - "github.com/tklauser/numcpus"
+          - "github.com/yusufpapurcu/wmi"
+          - "golang.org/x/sys"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-merge patch and minor updates
+      # Allowlisted by dependency group, not just semver level: the "fyne"
+      # group (see dependabot.yml) covers a GUI framework this app is deeply
+      # integrated with, and its live-wiring code isn't covered by tests the
+      # way the rest of the app is — those PRs always wait for manual review,
+      # even on a patch bump.
+      - name: Auto-merge patch and minor updates in the safe dependency groups
         if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor'
+          (steps.meta.outputs.dependency-group == 'go-dependencies-safe' ||
+           steps.meta.outputs.dependency-group == 'github-actions') &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ game-launcher
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- Dependabot auto-merges patch/minor Go dependency bumps once CI is green, and all Go deps were grouped into a single PR — so a `fyne.io/fyne/v2` update rode through on the same gate as `fsnotify`/`gopsutil`/`yaml.v3`.
- Coverage on the code wrapping those three small deps is strong (85-100%), but this app is deeply integrated with Fyne (custom widgets, a custom `fyne.Layout`, a custom theme, systray) and none of that live-wiring is covered by tests — so a Fyne bump was getting the same trust as the well-tested code, without deserving it.
- Splits the Dependabot group into an explicit allowlist of the well-tested deps (still auto-merges) and everything else — in practice Fyne's whole tree — which now always waits for manual review regardless of update-type.

## Test plan
- [x] Validated both `dependabot.yml` and `ci.yml` as well-formed YAML
- [ ] Confirm on the next Dependabot run that a `fyne.io/*` bump opens as a normal PR (no auto-merge) and a bump to `fsnotify`/`gopsutil`/`yaml.v3` still auto-merges on green CI